### PR TITLE
Disabled vertical scroll

### DIFF
--- a/lib/src/basic_day_based_widget.dart
+++ b/lib/src/basic_day_based_widget.dart
@@ -177,6 +177,7 @@ class DayBasedPicker<T> extends StatelessWidget with CommonDatePickerFunctions{
         children: <Widget>[
           Flexible(
             child: GridView.custom(
+              physics: NeverScrollableScrollPhysics(),
               gridDelegate: datePickerLayoutSettings.dayPickerGridDelegate,
               childrenDelegate:
               SliverChildListDelegate(labels, addRepaintBoundaries: false),


### PR DESCRIPTION
Calendar area prevented scrolling the entire page due to vertical scroll property of a GridView. Solved by adding physics: NeverScrollableScrollPhysics() to the Gridview.custom.