### PR TITLE
Code style refactoring

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,67 @@
+linter:
+  rules:
+    # STYLE
+    camel_case_types: true
+    camel_case_extensions: true
+    library_names: true
+    file_names: true
+    library_prefixes: true
+    non_constant_identifier_names: true
+    constant_identifier_names: true
+    directives_ordering: true
+    lines_longer_than_80_chars: true
+    curly_braces_in_flow_control_structures: true
+
+    # DOCUMENTATION
+    slash_for_doc_comments: true
+    package_api_docs: true
+    public_member_api_docs: true
+    comment_references: true
+
+    # USAGE
+    implementation_imports: true
+    avoid_relative_lib_imports: true
+    prefer_relative_imports: true
+    prefer_adjacent_string_concatenation: true
+    prefer_interpolation_to_compose_strings: true
+    unnecessary_brace_in_string_interps: true
+    prefer_collection_literals: true
+    prefer_is_empty: true
+    prefer_is_not_empty: true
+    avoid_function_literals_in_foreach_calls: true
+    prefer_iterable_whereType: true
+    prefer_function_declarations_over_variables: true
+    unnecessary_lambdas: true
+    prefer_equal_for_default_values: true
+    avoid_init_to_null: true
+    unnecessary_getters_setters: true
+    unnecessary_getters: true
+    prefer_expression_function_bodies: true
+    unnecessary_this: true
+    unnecessary_const: true
+    avoid_catches_without_on_clauses: true
+    avoid_catching_errors: true
+    use_rethrow_when_possible: true
+
+    # DESIGN
+    use_to_and_as_if_applicable: true
+    one_member_abstracts: true
+    avoid_classes_with_only_static_members: true
+    prefer_mixin: true
+    prefer_final_fields: true
+    use_setters_to_change_properties: true
+    avoid_setters_without_getters: true
+    avoid_returning_null: true
+    avoid_returning_this: true
+    type_annotate_public_apis: true
+    prefer_typing_uninitialized_variables: true
+#    omit_local_variable_types: true
+    avoid_types_on_closure_parameters: true
+    avoid_return_types_on_setters: true
+    prefer_generic_function_type_aliases: true
+    avoid_private_typedef_functions: true
+    use_function_type_syntax_for_parameters: true
+    avoid_positional_boolean_parameters: true
+    hash_and_equals: true
+    avoid_equals_and_hash_code_on_mutable_classes: true
+    avoid_null_checks_in_equality_operators: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -65,3 +65,30 @@ linter:
     hash_and_equals: true
     avoid_equals_and_hash_code_on_mutable_classes: true
     avoid_null_checks_in_equality_operators: true
+
+
+    # PEDANTIC
+    # (duplicated rules are removed)
+    always_declare_return_types: true
+    always_require_non_null_named_parameters: true
+    annotate_overrides: true
+    avoid_empty_else: true
+    avoid_shadowing_type_parameters: true
+    avoid_types_as_parameter_names: true
+    empty_catches: true
+    empty_constructor_bodies: true
+    no_duplicate_case_values: true
+    null_closures: true
+    prefer_conditional_assignment: true
+    prefer_contains: true
+    prefer_for_elements_to_map_fromIterable: true
+    prefer_if_null_operators: true
+#    prefer_single_quotes: true
+    prefer_spread_collections: true
+    recursive_getters: true
+    type_init_formals: true
+    unawaited_futures: true
+    unnecessary_new: true
+    unnecessary_null_in_if_null_operators: true
+    unrelated_type_equality_checks: true
+    valid_regexps: true

--- a/example/lib/color_picker_dialog.dart
+++ b/example/lib/color_picker_dialog.dart
@@ -1,9 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_material_color_picker/flutter_material_color_picker.dart';
 
+/// Dialog with some Material colors ([materialColors]) to pick one of them.
 class ColorPickerDialog extends StatefulWidget {
+
+  /// Initially selected color.
+  ///
+  /// If pre-selected color is not from [materialColors] [Colors.blue] will be
+  /// used.
   final Color selectedColor;
 
+  ///
   const ColorPickerDialog({Key key, this.selectedColor}) : super(key: key);
 
   @override
@@ -18,12 +25,12 @@ class _ColorPickerDialogState extends State<ColorPickerDialog> {
     super.initState();
 
     _mainColor = !materialColors.contains(widget.selectedColor)
-        ? Colors
-            .blue // pre-select color if [widget.selectedColor] is not in main material colors palette
+        ? Colors.blue
         : widget.selectedColor;
   }
 
   @override
+  // ignore: prefer_expression_function_bodies
   Widget build(BuildContext context) {
     return AlertDialog(
       contentPadding: const EdgeInsets.all(6.0),

--- a/example/lib/color_selector_btn.dart
+++ b/example/lib/color_selector_btn.dart
@@ -3,18 +3,23 @@ import 'package:flutter/material.dart';
 // default with and height for the button container
 const double _kBtnSize = 24.0;
 
-// round colored button with title to select some style color
+/// Round colored button with title to select some style color.
 class ColorSelectorBtn extends StatelessWidget {
-  // title near color button
+  /// Title near color button.
   final String title;
 
+  /// Color of the button.
   final Color color;
 
-  // onTap callback
+  /// onTap callback.
   final Function showDialogFunction;
 
+  /// Size of the circle.
+  ///
+  /// By default is [_kBtnSize].
   final double colorBtnSize;
 
+  ///
   const ColorSelectorBtn(
       {Key key,
       @required this.title,
@@ -24,6 +29,7 @@ class ColorSelectorBtn extends StatelessWidget {
       : super(key: key);
 
   @override
+  // ignore: prefer_expression_function_bodies
   Widget build(BuildContext context) {
     return Expanded(
       child: Row(

--- a/example/lib/date_pickers_widgets/day_picker_page.dart
+++ b/example/lib/date_pickers_widgets/day_picker_page.dart
@@ -1,18 +1,26 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_date_picker/color_picker_dialog.dart';
-import 'package:flutter_date_picker/color_selector_btn.dart';
 import 'package:flutter_date_pickers/flutter_date_pickers.dart' as dp;
 
-class MonthPickerPage extends StatefulWidget {
+import '../color_picker_dialog.dart';
+import '../color_selector_btn.dart';
+import '../event.dart';
+
+/// Page with [dp.DayPicker].
+class DayPickerPage extends StatefulWidget {
+  /// Custom events.
+  final List<Event> events;
+
+  ///
+  const DayPickerPage({Key key, this.events}) : super(key: key);
+
   @override
-  State<StatefulWidget> createState() => _MonthPickerPageState();
+  State<StatefulWidget> createState() => _DayPickerPageState();
 }
 
-class _MonthPickerPageState extends State<MonthPickerPage> {
+class _DayPickerPageState extends State<DayPickerPage> {
+  DateTime _selectedDate;
   DateTime _firstDate;
   DateTime _lastDate;
-  DateTime _selectedDate;
-
   Color selectedDateStyleColor;
   Color selectedSingleDateDecorationColor;
 
@@ -20,10 +28,9 @@ class _MonthPickerPageState extends State<MonthPickerPage> {
   void initState() {
     super.initState();
 
-    _firstDate = DateTime.now().subtract(Duration(days: 350));
-    _lastDate = DateTime.now().add(Duration(days: 350));
-
     _selectedDate = DateTime.now();
+    _firstDate = DateTime.now().subtract(Duration(days: 45));
+    _lastDate = DateTime.now().add(Duration(days: 45));
   }
 
   @override
@@ -38,7 +45,7 @@ class _MonthPickerPageState extends State<MonthPickerPage> {
   @override
   Widget build(BuildContext context) {
     // add selected colors to default settings
-    dp.DatePickerStyles styles = dp.DatePickerStyles(
+    dp.DatePickerStyles styles = dp.DatePickerRangeStyles(
         selectedDateStyle: Theme.of(context)
             .accentTextTheme
             .bodyText1
@@ -52,12 +59,19 @@ class _MonthPickerPageState extends State<MonthPickerPage> {
           : Axis.horizontal,
       children: <Widget>[
         Expanded(
-          child: dp.MonthPicker(
+          child: dp.DayPicker(
             selectedDate: _selectedDate,
             onChanged: _onSelectedDateChanged,
             firstDate: _firstDate,
             lastDate: _lastDate,
             datePickerStyles: styles,
+            datePickerLayoutSettings: dp.DatePickerLayoutSettings(
+                maxDayPickerRowCount: 2,
+                showPrevMonthEnd: true,
+                showNextMonthStart: true
+            ),
+            selectableDayPredicate: _isSelectableCustom,
+            eventDecorationBuilder: _eventDecorationBuilder,
           ),
         ),
         Container(
@@ -111,10 +125,11 @@ class _MonthPickerPageState extends State<MonthPickerPage> {
               selectedColor: selectedDateStyleColor,
             ));
 
-    if (newSelectedColor != null)
+    if (newSelectedColor != null) {
       setState(() {
         selectedDateStyleColor = newSelectedColor;
       });
+    }
   }
 
   // select background color of the selected date
@@ -125,15 +140,42 @@ class _MonthPickerPageState extends State<MonthPickerPage> {
               selectedColor: selectedSingleDateDecorationColor,
             ));
 
-    if (newSelectedColor != null)
+    if (newSelectedColor != null) {
       setState(() {
         selectedSingleDateDecorationColor = newSelectedColor;
       });
+    }
   }
 
   void _onSelectedDateChanged(DateTime newDate) {
     setState(() {
       _selectedDate = newDate;
     });
+  }
+
+  // ignore: prefer_expression_function_bodies
+  bool _isSelectableCustom (DateTime day) {
+    return day.weekday < 6;
+  }
+
+  dp.EventDecoration _eventDecorationBuilder(DateTime date) {
+    List<DateTime> eventsDates = widget.events
+        ?.map<DateTime>((Event e) => e.date)
+        ?.toList();
+
+    bool isEventDate = eventsDates?.any((DateTime d) => date.year == d.year
+        && date.month == d.month
+        && d.day == date.day) ?? false;
+
+    BoxDecoration roundedBorder = BoxDecoration(
+        border: Border.all(
+          color: Colors.deepOrange,
+        ),
+        borderRadius: BorderRadius.all(Radius.circular(3.0))
+    );
+
+    return isEventDate
+        ? dp.EventDecoration(boxDecoration: roundedBorder)
+        : null;
   }
 }

--- a/example/lib/date_pickers_widgets/month_picker_page.dart
+++ b/example/lib/date_pickers_widgets/month_picker_page.dart
@@ -1,22 +1,20 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_date_picker/event.dart';
-import 'package:flutter_date_picker/color_picker_dialog.dart';
-import 'package:flutter_date_picker/color_selector_btn.dart';
 import 'package:flutter_date_pickers/flutter_date_pickers.dart' as dp;
 
-class DayPickerPage extends StatefulWidget {
-  final List<Event> events;
+import '../color_picker_dialog.dart';
+import '../color_selector_btn.dart';
 
-  const DayPickerPage({Key key, this.events}) : super(key: key);
-
+/// Page with the [dp.MonthPicker].
+class MonthPickerPage extends StatefulWidget {
   @override
-  State<StatefulWidget> createState() => _DayPickerPageState();
+  State<StatefulWidget> createState() => _MonthPickerPageState();
 }
 
-class _DayPickerPageState extends State<DayPickerPage> {
-  DateTime _selectedDate;
+class _MonthPickerPageState extends State<MonthPickerPage> {
   DateTime _firstDate;
   DateTime _lastDate;
+  DateTime _selectedDate;
+
   Color selectedDateStyleColor;
   Color selectedSingleDateDecorationColor;
 
@@ -24,9 +22,10 @@ class _DayPickerPageState extends State<DayPickerPage> {
   void initState() {
     super.initState();
 
+    _firstDate = DateTime.now().subtract(Duration(days: 350));
+    _lastDate = DateTime.now().add(Duration(days: 350));
+
     _selectedDate = DateTime.now();
-    _firstDate = DateTime.now().subtract(Duration(days: 45));
-    _lastDate = DateTime.now().add(Duration(days: 45));
   }
 
   @override
@@ -41,7 +40,7 @@ class _DayPickerPageState extends State<DayPickerPage> {
   @override
   Widget build(BuildContext context) {
     // add selected colors to default settings
-    dp.DatePickerStyles styles = dp.DatePickerRangeStyles(
+    dp.DatePickerStyles styles = dp.DatePickerStyles(
         selectedDateStyle: Theme.of(context)
             .accentTextTheme
             .bodyText1
@@ -55,19 +54,12 @@ class _DayPickerPageState extends State<DayPickerPage> {
           : Axis.horizontal,
       children: <Widget>[
         Expanded(
-          child: dp.DayPicker(
+          child: dp.MonthPicker(
             selectedDate: _selectedDate,
             onChanged: _onSelectedDateChanged,
             firstDate: _firstDate,
             lastDate: _lastDate,
             datePickerStyles: styles,
-            datePickerLayoutSettings: dp.DatePickerLayoutSettings(
-                maxDayPickerRowCount: 2,
-                showPrevMonthEnd: true,
-                showNextMonthStart: true
-            ),
-            selectableDayPredicate: _isSelectableCustom,
-            eventDecorationBuilder: _eventDecorationBuilder,
           ),
         ),
         Container(
@@ -121,10 +113,11 @@ class _DayPickerPageState extends State<DayPickerPage> {
               selectedColor: selectedDateStyleColor,
             ));
 
-    if (newSelectedColor != null)
+    if (newSelectedColor != null) {
       setState(() {
         selectedDateStyleColor = newSelectedColor;
       });
+    }
   }
 
   // select background color of the selected date
@@ -135,35 +128,16 @@ class _DayPickerPageState extends State<DayPickerPage> {
               selectedColor: selectedSingleDateDecorationColor,
             ));
 
-    if (newSelectedColor != null)
+    if (newSelectedColor != null) {
       setState(() {
         selectedSingleDateDecorationColor = newSelectedColor;
       });
+    }
   }
 
   void _onSelectedDateChanged(DateTime newDate) {
     setState(() {
       _selectedDate = newDate;
     });
-  }
-
-  bool _isSelectableCustom (DateTime day) {
-    return day.weekday < 6;
-  }
-
-  dp.EventDecoration _eventDecorationBuilder(DateTime date) {
-    List<DateTime> eventsDates = widget.events?.map<DateTime>((Event e) => e.date)?.toList();
-    bool isEventDate = eventsDates?.any((DateTime d) => date.year == d.year && date.month == d.month && d.day == date.day) ?? false;
-
-    BoxDecoration roundedBorder = BoxDecoration(
-        border: Border.all(
-          color: Colors.deepOrange,
-        ),
-        borderRadius: BorderRadius.all(Radius.circular(3.0))
-    );
-
-    return isEventDate
-        ? dp.EventDecoration(boxDecoration: roundedBorder)
-        : null;
   }
 }

--- a/example/lib/date_pickers_widgets/range_picker_page.dart
+++ b/example/lib/date_pickers_widgets/range_picker_page.dart
@@ -1,20 +1,24 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_date_picker/event.dart';
-import 'package:flutter_date_picker/color_picker_dialog.dart';
-import 'package:flutter_date_picker/color_selector_btn.dart';
 import 'package:flutter_date_pickers/flutter_date_pickers.dart';
 
-class WeekPickerPage extends StatefulWidget {
+import '../color_picker_dialog.dart';
+import '../color_selector_btn.dart';
+import '../event.dart';
+
+/// Page with the [RangePicker].
+class RangePickerPage extends StatefulWidget {
+
+  /// Custom events.
   final List<Event> events;
 
-  const WeekPickerPage({Key key, this.events}) : super(key: key);
+  ///
+  const RangePickerPage({Key key, this.events}) : super(key: key);
 
   @override
-  State<StatefulWidget> createState() => _WeekPickerPageState();
+  State<StatefulWidget> createState() => _RangePickerPageState();
 }
 
-class _WeekPickerPageState extends State<WeekPickerPage> {
-  DateTime _selectedDate;
+class _RangePickerPageState extends State<RangePickerPage> {
   DateTime _firstDate;
   DateTime _lastDate;
   DatePeriod _selectedPeriod;
@@ -27,9 +31,12 @@ class _WeekPickerPageState extends State<WeekPickerPage> {
   void initState() {
     super.initState();
 
-    _selectedDate = DateTime.now();
     _firstDate = DateTime.now().subtract(Duration(days: 45));
     _lastDate = DateTime.now().add(Duration(days: 45));
+
+    DateTime selectedPeriodStart = DateTime.now().subtract(Duration(days: 4));
+    DateTime selectedPeriodEnd = DateTime.now().add(Duration(days: 8));
+    _selectedPeriod = DatePeriod(selectedPeriodStart, selectedPeriodEnd);
   }
 
   @override
@@ -48,16 +55,21 @@ class _WeekPickerPageState extends State<WeekPickerPage> {
     DatePickerRangeStyles styles = DatePickerRangeStyles(
       selectedPeriodLastDecoration: BoxDecoration(
           color: selectedPeriodLastColor,
-          borderRadius: BorderRadius.only(
-              topRight: Radius.circular(10.0),
-              bottomRight: Radius.circular(10.0))),
+          borderRadius: const BorderRadius.only(
+              topRight: Radius.circular(24.0),
+              bottomRight: Radius.circular(24.0))),
       selectedPeriodStartDecoration: BoxDecoration(
         color: selectedPeriodStartColor,
-        borderRadius: BorderRadius.only(
-            topLeft: Radius.circular(10.0), bottomLeft: Radius.circular(10.0)),
+        borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(24.0),
+            bottomLeft: Radius.circular(24.0)
+        ),
       ),
       selectedPeriodMiddleDecoration: BoxDecoration(
           color: selectedPeriodMiddleColor, shape: BoxShape.rectangle),
+      nextIcon: const Icon(Icons.arrow_right),
+      prevIcon: const Icon(Icons.arrow_left),
+      dayHeaderStyleBuilder: _dayHeaderStyleBuilder
     );
 
     return Flex(
@@ -66,15 +78,14 @@ class _WeekPickerPageState extends State<WeekPickerPage> {
           : Axis.horizontal,
       children: <Widget>[
         Expanded(
-          child: WeekPicker(
-            selectedDate: _selectedDate,
+          child: RangePicker(
+            selectedPeriod: _selectedPeriod,
             onChanged: _onSelectedDateChanged,
             firstDate: _firstDate,
             lastDate: _lastDate,
             datePickerStyles: styles,
-            onSelectionError: _onSelectionError,
-            selectableDayPredicate: _isSelectableCustom,
             eventDecorationBuilder: _eventDecorationBuilder,
+            selectableDayPredicate: _isSelectableCustom,
           ),
         ),
         Container(
@@ -98,9 +109,26 @@ class _WeekPickerPageState extends State<WeekPickerPage> {
     );
   }
 
-  // block witt color buttons insede
-  Widget _stylesBlock() {
-    return Padding(
+  // Block with show information about selected date
+  // and boundaries of the selected period.
+  Widget _selectedBlock() => Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        _selectedPeriod != null
+            ? Column(children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
+                  child: Text("Selected period boundaries:"),
+                ),
+                Text(_selectedPeriod.start.toString()),
+                Text(_selectedPeriod.end.toString()),
+              ])
+            : Container()
+      ],
+    );
+
+  // block with color buttons inside
+  Widget _stylesBlock() => Padding(
       padding: const EdgeInsets.symmetric(vertical: 12.0),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -126,30 +154,6 @@ class _WeekPickerPageState extends State<WeekPickerPage> {
         ],
       ),
     );
-  }
-
-  // block witch show information about selected date and boundaries of the selected period
-  Widget _selectedBlock() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Padding(
-          padding: const EdgeInsets.only(top: 8.0),
-          child: Text("Selected: $_selectedDate"),
-        ),
-        _selectedPeriod != null
-            ? Column(children: <Widget>[
-                Padding(
-                  padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
-                  child: Text("Selected period boundaries:"),
-                ),
-                Text(_selectedPeriod.start.toString()),
-                Text(_selectedPeriod.end.toString()),
-              ])
-            : Container()
-      ],
-    );
-  }
 
   // select background color for the first date of the selected period
   void _showSelectedStartColorDialog() async {
@@ -159,10 +163,11 @@ class _WeekPickerPageState extends State<WeekPickerPage> {
               selectedColor: selectedPeriodStartColor,
             ));
 
-    if (newSelectedColor != null)
+    if (newSelectedColor != null) {
       setState(() {
         selectedPeriodStartColor = newSelectedColor;
       });
+    }
   }
 
   // select background color for the last date of the selected period
@@ -173,10 +178,11 @@ class _WeekPickerPageState extends State<WeekPickerPage> {
               selectedColor: selectedPeriodLastColor,
             ));
 
-    if (newSelectedColor != null)
+    if (newSelectedColor != null) {
       setState(() {
         selectedPeriodLastColor = newSelectedColor;
       });
+    }
   }
 
   // select background color for the middle dates of the selected period
@@ -187,44 +193,55 @@ class _WeekPickerPageState extends State<WeekPickerPage> {
               selectedColor: selectedPeriodMiddleColor,
             ));
 
-    if (newSelectedColor != null)
+    if (newSelectedColor != null) {
       setState(() {
         selectedPeriodMiddleColor = newSelectedColor;
       });
+    }
   }
 
   void _onSelectedDateChanged(DatePeriod newPeriod) {
     setState(() {
-      _selectedDate = newPeriod.start;
       _selectedPeriod = newPeriod;
     });
   }
 
-  void _onSelectionError(Object e){
-    if (e is UnselectablePeriodException) print("catch error: $e");
-  }
-
-  bool _isSelectableCustom (DateTime day) {
-//    return day.weekday < 6;
-    return day.day != DateTime.now().add(Duration(days: 7)).day ;
-  }
-
   EventDecoration _eventDecorationBuilder(DateTime date) {
-    List<DateTime> eventsDates = widget.events?.map<DateTime>((Event e) => e.date)?.toList();
-    bool isEventDate = eventsDates?.any((DateTime d) => date.year == d.year && date.month == d.month && d.day == date.day) ?? false;
+    List<DateTime> eventsDates = widget.events
+        ?.map<DateTime>((Event e) => e.date)
+        ?.toList();
+
+    bool isEventDate = eventsDates?.any((DateTime d) => date.year == d.year
+        && date.month == d.month
+        && d.day == date.day) ?? false;
 
     BoxDecoration roundedBorder = BoxDecoration(
-        color: Colors.blue,
         border: Border.all(
-          color: Colors.blue,
+          color: Colors.green,
         ),
         borderRadius: BorderRadius.all(Radius.circular(3.0))
     );
 
-    TextStyle whiteText = Theme.of(context).textTheme.bodyText2.copyWith(color: Colors.white);
-
     return isEventDate
-        ? EventDecoration(boxDecoration: roundedBorder, textStyle: whiteText)
+        ? EventDecoration(boxDecoration: roundedBorder)
         : null;
+  }
+
+  // ignore: prefer_expression_function_bodies
+  bool _isSelectableCustom (DateTime day) {
+    return true;
+//    return day.weekday < 6;
+//    return day.day != DateTime.now().add(Duration(days: 7)).day ;
+  }
+
+  // 0 is Sunday, 6 is Saturday
+  DayHeaderStyle _dayHeaderStyleBuilder(int weekday) {
+    bool isWeekend = weekday == 0 || weekday == 6;
+
+    return DayHeaderStyle(
+        textStyle: TextStyle(
+            color: isWeekend ? Colors.red : Colors.teal
+        )
+    );
   }
 }

--- a/example/lib/date_pickers_widgets/week_picker_page.dart
+++ b/example/lib/date_pickers_widgets/week_picker_page.dart
@@ -1,19 +1,24 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_date_picker/event.dart';
-import 'package:flutter_date_picker/color_picker_dialog.dart';
-import 'package:flutter_date_picker/color_selector_btn.dart';
 import 'package:flutter_date_pickers/flutter_date_pickers.dart';
 
-class RangePickerPage extends StatefulWidget {
+import '../color_picker_dialog.dart';
+import '../color_selector_btn.dart';
+import '../event.dart';
+
+/// Page with the [WeekPicker].
+class WeekPickerPage extends StatefulWidget {
+  /// Custom events.
   final List<Event> events;
 
-  const RangePickerPage({Key key, this.events}) : super(key: key);
+  ///
+  const WeekPickerPage({Key key, this.events}) : super(key: key);
 
   @override
-  State<StatefulWidget> createState() => _RangePickerPageState();
+  State<StatefulWidget> createState() => _WeekPickerPageState();
 }
 
-class _RangePickerPageState extends State<RangePickerPage> {
+class _WeekPickerPageState extends State<WeekPickerPage> {
+  DateTime _selectedDate;
   DateTime _firstDate;
   DateTime _lastDate;
   DatePeriod _selectedPeriod;
@@ -26,12 +31,9 @@ class _RangePickerPageState extends State<RangePickerPage> {
   void initState() {
     super.initState();
 
+    _selectedDate = DateTime.now();
     _firstDate = DateTime.now().subtract(Duration(days: 45));
     _lastDate = DateTime.now().add(Duration(days: 45));
-
-    DateTime selectedPeriodStart = DateTime.now().subtract(Duration(days: 4));
-    DateTime selectedPeriodEnd = DateTime.now().add(Duration(days: 8));
-    _selectedPeriod = DatePeriod(selectedPeriodStart, selectedPeriodEnd);
   }
 
   @override
@@ -50,21 +52,16 @@ class _RangePickerPageState extends State<RangePickerPage> {
     DatePickerRangeStyles styles = DatePickerRangeStyles(
       selectedPeriodLastDecoration: BoxDecoration(
           color: selectedPeriodLastColor,
-          borderRadius: const BorderRadius.only(
-              topRight: Radius.circular(24.0),
-              bottomRight: Radius.circular(24.0))),
+          borderRadius: BorderRadius.only(
+              topRight: Radius.circular(10.0),
+              bottomRight: Radius.circular(10.0))),
       selectedPeriodStartDecoration: BoxDecoration(
         color: selectedPeriodStartColor,
-        borderRadius: const BorderRadius.only(
-            topLeft: Radius.circular(24.0),
-            bottomLeft: Radius.circular(24.0)
-        ),
+        borderRadius: BorderRadius.only(
+            topLeft: Radius.circular(10.0), bottomLeft: Radius.circular(10.0)),
       ),
       selectedPeriodMiddleDecoration: BoxDecoration(
           color: selectedPeriodMiddleColor, shape: BoxShape.rectangle),
-      nextIcon: const Icon(Icons.arrow_right),
-      prevIcon: const Icon(Icons.arrow_left),
-      dayHeaderStyleBuilder: _dayHeaderStyleBuilder
     );
 
     return Flex(
@@ -73,14 +70,15 @@ class _RangePickerPageState extends State<RangePickerPage> {
           : Axis.horizontal,
       children: <Widget>[
         Expanded(
-          child: RangePicker(
-            selectedPeriod: _selectedPeriod,
+          child: WeekPicker(
+            selectedDate: _selectedDate,
             onChanged: _onSelectedDateChanged,
             firstDate: _firstDate,
             lastDate: _lastDate,
             datePickerStyles: styles,
-            eventDecorationBuilder: _eventDecorationBuilder,
+            onSelectionError: _onSelectionError,
             selectableDayPredicate: _isSelectableCustom,
+            eventDecorationBuilder: _eventDecorationBuilder,
           ),
         ),
         Container(
@@ -104,28 +102,8 @@ class _RangePickerPageState extends State<RangePickerPage> {
     );
   }
 
-  // block witch show information about selected date and boundaries of the selected period
-  Widget _selectedBlock() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        _selectedPeriod != null
-            ? Column(children: <Widget>[
-                Padding(
-                  padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
-                  child: Text("Selected period boundaries:"),
-                ),
-                Text(_selectedPeriod.start.toString()),
-                Text(_selectedPeriod.end.toString()),
-              ])
-            : Container()
-      ],
-    );
-  }
-
   // block witt color buttons insede
-  Widget _stylesBlock() {
-    return Padding(
+  Widget _stylesBlock() => Padding(
       padding: const EdgeInsets.symmetric(vertical: 12.0),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -151,7 +129,28 @@ class _RangePickerPageState extends State<RangePickerPage> {
         ],
       ),
     );
-  }
+
+  // Block with  information about selected date
+  // and boundaries of the selected period.
+  Widget _selectedBlock() => Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Padding(
+          padding: const EdgeInsets.only(top: 8.0),
+          child: Text("Selected: $_selectedDate"),
+        ),
+        _selectedPeriod != null
+            ? Column(children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
+                  child: Text("Selected period boundaries:"),
+                ),
+                Text(_selectedPeriod.start.toString()),
+                Text(_selectedPeriod.end.toString()),
+              ])
+            : Container()
+      ],
+    );
 
   // select background color for the first date of the selected period
   void _showSelectedStartColorDialog() async {
@@ -161,10 +160,11 @@ class _RangePickerPageState extends State<RangePickerPage> {
               selectedColor: selectedPeriodStartColor,
             ));
 
-    if (newSelectedColor != null)
+    if (newSelectedColor != null) {
       setState(() {
         selectedPeriodStartColor = newSelectedColor;
       });
+    }
   }
 
   // select background color for the last date of the selected period
@@ -175,10 +175,11 @@ class _RangePickerPageState extends State<RangePickerPage> {
               selectedColor: selectedPeriodLastColor,
             ));
 
-    if (newSelectedColor != null)
+    if (newSelectedColor != null) {
       setState(() {
         selectedPeriodLastColor = newSelectedColor;
       });
+    }
   }
 
   // select background color for the middle dates of the selected period
@@ -189,48 +190,54 @@ class _RangePickerPageState extends State<RangePickerPage> {
               selectedColor: selectedPeriodMiddleColor,
             ));
 
-    if (newSelectedColor != null)
+    if (newSelectedColor != null) {
       setState(() {
         selectedPeriodMiddleColor = newSelectedColor;
       });
+    }
   }
 
   void _onSelectedDateChanged(DatePeriod newPeriod) {
     setState(() {
+      _selectedDate = newPeriod.start;
       _selectedPeriod = newPeriod;
     });
   }
 
+  void _onSelectionError(Object e){
+    if (e is UnselectablePeriodException) print("catch error: $e");
+  }
+
+// ignore: prefer_expression_function_bodies
+  bool _isSelectableCustom (DateTime day) {
+//    return day.weekday < 6;
+    return day.day != DateTime.now().add(Duration(days: 7)).day ;
+  }
+
   EventDecoration _eventDecorationBuilder(DateTime date) {
-    List<DateTime> eventsDates = widget.events?.map<DateTime>((Event e) => e.date)?.toList();
-    bool isEventDate = eventsDates?.any((DateTime d) => date.year == d.year && date.month == d.month && d.day == date.day) ?? false;
+    List<DateTime> eventsDates = widget.events
+        ?.map<DateTime>((Event e) => e.date)
+        ?.toList();
+
+    bool isEventDate = eventsDates?.any((DateTime d) => date.year == d.year
+        && date.month == d.month
+        && d.day == date.day) ?? false;
 
     BoxDecoration roundedBorder = BoxDecoration(
+        color: Colors.blue,
         border: Border.all(
-          color: Colors.green,
+          color: Colors.blue,
         ),
         borderRadius: BorderRadius.all(Radius.circular(3.0))
     );
 
+    TextStyle whiteText = Theme.of(context)
+        .textTheme
+        .bodyText2
+        .copyWith(color: Colors.white);
+
     return isEventDate
-        ? EventDecoration(boxDecoration: roundedBorder)
+        ? EventDecoration(boxDecoration: roundedBorder, textStyle: whiteText)
         : null;
-  }
-
-  bool _isSelectableCustom (DateTime day) {
-    return true;
-//    return day.weekday < 6;
-//    return day.day != DateTime.now().add(Duration(days: 7)).day ;
-  }
-
-  // 0 is Sunday, 6 is Saturday
-  DayHeaderStyle _dayHeaderStyleBuilder(int weekday) {
-    bool isWeekend = weekday == 0 || weekday == 6;
-
-    return DayHeaderStyle(
-        textStyle: TextStyle(
-            color: isWeekend ? Colors.red : Colors.teal
-        )
-    );
   }
 }

--- a/example/lib/event.dart
+++ b/example/lib/event.dart
@@ -1,7 +1,13 @@
+/// Event for the date pickers.
 class Event {
+
+  /// Event's date.
   final DateTime date;
+
+  /// Event's title.
   final String dis;
 
+  ///
   Event(this.date, this.dis)
       : assert(date != null),
         assert(dis != null);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,18 +1,22 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_date_picker/event.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
-import 'DatePickersWidgets/month_picker_page.dart';
-import 'DatePickersWidgets/day_picker_page.dart';
-import 'DatePickersWidgets/range_picker_page.dart';
-import 'DatePickersWidgets/week_picker_page.dart';
+import 'date_pickers_widgets/day_picker_page.dart';
+import 'date_pickers_widgets/month_picker_page.dart';
+import 'date_pickers_widgets/range_picker_page.dart';
+import 'date_pickers_widgets/week_picker_page.dart';
+
+import 'event.dart';
 
 void main() {
   runApp(MyApp());
 }
 
+///
 class MyApp extends StatelessWidget {
+
   @override
+    // ignore: prefer_expression_function_bodies
   Widget build(BuildContext context) {
     return MaterialApp(
       localizationsDelegates: GlobalMaterialLocalizations.delegates,
@@ -34,9 +38,12 @@ class MyApp extends StatelessWidget {
   }
 }
 
+/// Start page.
 class MyHomePage extends StatefulWidget {
+  /// Page title.
   final String title;
 
+  ///
   MyHomePage({Key key, this.title}) : super(key: key);
 
   @override
@@ -74,6 +81,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
   }
 
   @override
+    // ignore: prefer_expression_function_bodies
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
@@ -113,6 +121,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
   }
 }
 
+/// Mock events.
 final List<Event> events = [
   Event(DateTime.now(), "Today event"),
   Event(DateTime.now().subtract(Duration(days: 3)), "Ev1"),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -61,7 +61,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.6"
+    version: "0.1.7"
   flutter_localizations:
     dependency: "direct main"
     description: flutter

--- a/lib/src/date_period.dart
+++ b/lib/src/date_period.dart
@@ -1,7 +1,12 @@
+/// Date period.
 class DatePeriod {
+  /// Start of this period.
   final DateTime start;
+
+  /// End of this period.
   final DateTime end;
 
+  ///
   const DatePeriod(this.start, this.end)
       : assert(start != null),
         assert(end != null);

--- a/lib/src/date_picker_keys.dart
+++ b/lib/src/date_picker_keys.dart
@@ -1,12 +1,19 @@
 import 'package:flutter/material.dart';
 
-// class to provide keys for date pickers
-// useful for integration tests to find widgets
+/// Keys for some date picker's widgets.
+///
+/// Useful for integration tests to find widgets.
 class DatePickerKeys {
+  /// Key for the previous page icon widget.
   final Key previousPageIconKey;
+
+  /// Key for the next page icon widget.
   final Key nextPageIconKey;
+
+  /// Key for showing month.
   final Key selectedPeriodKeys;
 
+  ///
   DatePickerKeys(
       this.previousPageIconKey, this.nextPageIconKey, this.selectedPeriodKeys);
 }

--- a/lib/src/date_picker_mixin.dart
+++ b/lib/src/date_picker_mixin.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_date_pickers/flutter_date_pickers.dart';
+
+import 'date_picker_styles.dart';
 
 mixin CommonDatePickerFunctions {
 
@@ -21,7 +22,11 @@ mixin CommonDatePickerFunctions {
   /// _ _ _ _ 1 2 3
   /// 4 5 6 7 8 9 10
   /// ```
-  List<Widget> getDayHeaders(DayHeaderStyleBuilder headerStyleBuilder, List<String> narrowWeekdays, int firstDayOfWeekIndex) {
+  List<Widget> getDayHeaders(
+      DayHeaderStyleBuilder headerStyleBuilder,
+      List<String> narrowWeekdays,
+      int firstDayOfWeekIndex) {
+
     final List<Widget> result = <Widget>[];
 
     for (int i = firstDayOfWeekIndex; true; i = (i + 1) % 7) {

--- a/lib/src/date_picker_styles.dart
+++ b/lib/src/date_picker_styles.dart
@@ -1,25 +1,33 @@
 import 'package:flutter/material.dart';
+import 'range_picker.dart';
+import 'week_picker.dart';
 
 /// 0 points to Sunday, and 6 points to Saturday.
-typedef DayHeaderStyle DayHeaderStyleBuilder(int dayOfTheWeek);
+typedef DayHeaderStyleBuilder = DayHeaderStyle Function(int dayOfTheWeek);
 
 /// Common styles for date pickers.
 ///
 /// To define more styles for date pickers which allow select some range
 /// (e.g. [RangePicker], [WeekPicker]) use [DatePickerRangeStyles].
+@immutable
 class DatePickerStyles {
-  /// Used for title of displayed period (e.g. month for day picker and year for month picker).
+  /// Styles for title of displayed period
+  /// (e.g. month for day picker and year for month picker).
   final TextStyle displayedPeriodTitle;
 
+  /// Style for the number of current date.
   final TextStyle currentDateStyle;
 
+  /// Style for the numbers of disabled dates.
   final TextStyle disabledDateStyle;
 
+  /// Style for the number of selected date.
   final TextStyle selectedDateStyle;
 
   /// Used for date which is neither current nor disabled nor selected.
   final TextStyle defaultDateTextStyle;
 
+  /// Day cell decoration for selected date in case only one date is selected.
   final BoxDecoration selectedSingleDateDecoration;
 
   /// Style for the day header.
@@ -33,7 +41,8 @@ class DatePickerStyles {
   ///
   /// Builder must return not null value for every weekday from 0 to 6.
   ///
-  /// If styles should be the same for any day of the week use [dayHeaderStyle] instead.
+  /// If styles should be the same for any day of the week
+  /// use [dayHeaderStyle] instead.
   final DayHeaderStyleBuilder dayHeaderStyleBuilder;
 
   /// Widget which will be shown left side of the shown page title.
@@ -50,6 +59,7 @@ class DatePickerStyles {
   /// Can be null. In this case value from current locale will be used.
   final int firstDayOfeWeekIndex;
 
+  /// Styles for date picker.
   DatePickerStyles({
     this.displayedPeriodTitle,
     this.currentDateStyle,
@@ -64,14 +74,17 @@ class DatePickerStyles {
     Widget nextIcon
   }) : assert(!(dayHeaderStyle != null && dayHeaderStyleBuilder != null),
         "Should be only one from: dayHeaderStyleBuilder, dayHeaderStyle."),
-       assert(dayHeaderStyleBuilder == null || _validateDayHeaderStyleBuilder(dayHeaderStyleBuilder),
-        "dayHeaderStyleBuilder must return not null value from every weekday (from 0 to 6)."),
+       assert(dayHeaderStyleBuilder == null
+           || _validateDayHeaderStyleBuilder(dayHeaderStyleBuilder),
+        "dayHeaderStyleBuilder must return not null value from every weekday "
+            "(from 0 to 6)."),
        assert(_validateFirstDayOfWeek(firstDayOfeWeekIndex),
         "firstDayOfeWeekIndex must be null or in correct range (from 0 to 6)."),
-      this.nextIcon = nextIcon ?? const Icon(Icons.chevron_right),
-      this.prevIcon = prevIcon ?? const Icon(Icons.chevron_left);
+      nextIcon = nextIcon ?? const Icon(Icons.chevron_right),
+      prevIcon = prevIcon ?? const Icon(Icons.chevron_left);
 
-  /// Return new [DatePickerStyles] object where fields with null values set with defaults from theme.
+  /// Return new [DatePickerStyles] object where fields
+  /// with null values set with defaults from theme.
   DatePickerStyles fulfillWithTheme(ThemeData theme) {
     Color accentColor = theme.accentColor;
 
@@ -112,10 +125,9 @@ class DatePickerStyles {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other))
-      return true;
-    if (other.runtimeType != runtimeType)
-      return false;
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+
     return other is DatePickerStyles
         && other.displayedPeriodTitle == displayedPeriodTitle
         && other.currentDateStyle == currentDateStyle
@@ -131,8 +143,8 @@ class DatePickerStyles {
   }
 
   @override
-  int get hashCode {
-    return hashValues(
+  int get hashCode =>
+     hashValues(
         displayedPeriodTitle,
         currentDateStyle,
         disabledDateStyle,
@@ -145,10 +157,11 @@ class DatePickerStyles {
         nextIcon,
         firstDayOfeWeekIndex
     );
-  }
 
   static bool _validateDayHeaderStyleBuilder(DayHeaderStyleBuilder builder) {
     List<int> weekdays = const [0, 1, 2, 3, 4, 5, 6];
+
+    // ignore: avoid_types_on_closure_parameters
     bool valid = weekdays.every((int weekday) => builder(weekday) != null);
 
     return valid;
@@ -163,7 +176,9 @@ class DatePickerStyles {
   }
 }
 
-/// Styles for date pickers which allow select some range (e.g. [RangePicker], [WeekPicker]).
+/// Styles for date pickers which allow select some range
+/// (e.g. RangePicker, WeekPicker).
+@immutable
 class DatePickerRangeStyles extends DatePickerStyles {
   /// Decoration for the first date of the selected range.
   final BoxDecoration selectedPeriodStartDecoration;
@@ -181,9 +196,11 @@ class DatePickerRangeStyles extends DatePickerStyles {
   /// If null - default [DatePickerStyles.selectedDateStyle] will be used.
   final TextStyle selectedPeriodEndTextStyle;
 
-  /// Decoration for the date of the selected range which is not first date and not end date of this range.
+  /// Decoration for the date of the selected range
+  /// which is not first date and not end date of this range.
   ///
-  /// If there is only one date selected [DatePickerStyles.selectedSingleDateDecoration] will be used.
+  /// If there is only one date selected
+  /// [DatePickerStyles.selectedSingleDateDecoration] will be used.
   final BoxDecoration selectedPeriodMiddleDecoration;
 
   /// Text style for the middle date of the selected range.
@@ -191,7 +208,8 @@ class DatePickerRangeStyles extends DatePickerStyles {
   /// If null - default [DatePickerStyles.selectedDateStyle] will be used.
   final TextStyle selectedPeriodMiddleTextStyle;
 
-  /// Return new [DatePickerRangeStyles] object where fields with null values set with defaults from given theme.
+  /// Return new [DatePickerRangeStyles] object
+  /// where fields with null values set with defaults from given theme.
   DatePickerRangeStyles fulfillWithTheme(ThemeData theme) {
     Color accentColor = theme.accentColor;
 
@@ -250,6 +268,8 @@ class DatePickerRangeStyles extends DatePickerStyles {
     );
   }
 
+  /// Styles for the pickers that allows to select range ([RangePicker],
+  /// [WeekPicker]).
   DatePickerRangeStyles({
     displayedPeriodTitle,
     currentDateStyle,
@@ -284,10 +304,9 @@ class DatePickerRangeStyles extends DatePickerStyles {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other))
-      return true;
-    if (other.runtimeType != runtimeType)
-      return false;
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+
     return other is DatePickerRangeStyles
         && other.selectedPeriodStartDecoration == selectedPeriodStartDecoration
         && other.selectedPeriodStartTextStyle == selectedPeriodStartTextStyle
@@ -309,8 +328,8 @@ class DatePickerRangeStyles extends DatePickerStyles {
   }
 
   @override
-  int get hashCode {
-    return hashValues(
+  int get hashCode =>
+     hashValues(
       selectedPeriodStartDecoration,
       selectedPeriodStartTextStyle,
       selectedPeriodLastDecoration,
@@ -329,18 +348,22 @@ class DatePickerRangeStyles extends DatePickerStyles {
       nextIcon,
       firstDayOfeWeekIndex
     );
-  }
 }
 
 
 /// Style for the day header in date picker.
+@immutable
 class DayHeaderStyle {
-  /// If null - [textTheme.caption] from the Theme will be used.
+  /// If null - textTheme.caption from the Theme will be used.
   final TextStyle textStyle;
 
   /// If null - no decoration will be applied for the day header;
   final BoxDecoration decoration;
 
+  /// Creates styles for the day headers in date pickers.
+  ///
+  /// See also:
+  /// * [DatePickerStyles.dayHeaderStyleBuilder]
   const DayHeaderStyle({
     this.textStyle,
     this.decoration
@@ -348,20 +371,17 @@ class DayHeaderStyle {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other))
-      return true;
-    if (other.runtimeType != runtimeType)
-      return false;
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+
     return other is DayHeaderStyle
         && other.textStyle == textStyle
         && other.decoration == decoration;
   }
 
   @override
-  int get hashCode {
-    return hashValues(
+  int get hashCode => hashValues(
       textStyle,
       decoration
     );
-  }
 }

--- a/lib/src/date_picker_styles.dart
+++ b/lib/src/date_picker_styles.dart
@@ -210,6 +210,7 @@ class DatePickerRangeStyles extends DatePickerStyles {
 
   /// Return new [DatePickerRangeStyles] object
   /// where fields with null values set with defaults from given theme.
+  @override
   DatePickerRangeStyles fulfillWithTheme(ThemeData theme) {
     Color accentColor = theme.accentColor;
 
@@ -312,7 +313,7 @@ class DatePickerRangeStyles extends DatePickerStyles {
         && other.selectedPeriodStartTextStyle == selectedPeriodStartTextStyle
         && other.selectedPeriodLastDecoration == selectedPeriodLastDecoration
         && other.selectedPeriodEndTextStyle == selectedPeriodEndTextStyle
-        && other.selectedPeriodMiddleDecoration == selectedPeriodMiddleDecoration
+        && other.selectedPeriodMiddleDecoration ==selectedPeriodMiddleDecoration
         && other.selectedPeriodMiddleTextStyle == selectedPeriodMiddleTextStyle
         && other.displayedPeriodTitle == displayedPeriodTitle
         && other.currentDateStyle == currentDateStyle

--- a/lib/src/day_picker.dart
+++ b/lib/src/day_picker.dart
@@ -1,23 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter_date_pickers/flutter_date_pickers.dart';
-import 'package:flutter_date_pickers/src/date_picker_styles.dart';
-import 'package:flutter_date_pickers/src/event_decoration.dart';
-import 'package:flutter_date_pickers/src/i_selectable_picker.dart';
-import 'package:flutter_date_pickers/src/layout_settings.dart';
-import 'package:flutter_date_pickers/src/date_picker_keys.dart';
-import 'package:flutter_date_pickers/src/day_based_changable_picker.dart';
 
-// Styles for current displayed period (month) title: Theme.of(context).textTheme.subhead
-//
-// Styles for date picker cell:
-// current date: Theme.of(context).textTheme.body2.copyWith(color: themeData.accentColor)
-// if date disabled: Theme.of(context).textTheme.body1.copyWith(color: themeData.disabledColor)
-// if date selected:
-//  text - Theme.of(context).accentTextTheme.body2
-//  for box decoration - color is Theme.of(context).accentColor and box shape is circle
-
-// selectedDate must be between firstDate and lastDate
+import 'date_picker_keys.dart';
+import 'date_picker_styles.dart';
+import 'day_based_changable_picker.dart';
+import 'day_type.dart';
+import 'event_decoration.dart';
+import 'i_selectable_picker.dart';
+import 'layout_settings.dart';
 
 /// Date picker for selection one day.
 class DayPicker extends StatelessWidget {

--- a/lib/src/day_type.dart
+++ b/lib/src/day_type.dart
@@ -1,8 +1,20 @@
+/// Type of the day in day based date picker.
 enum DayType {
+  /// start of the selected period
   start,
+
+  /// middle of the selected period
   middle,
+
+  /// end of the selected period
   end,
+
+  /// selected single day
   single,
+
+  /// disabled day
   disabled,
+
+  /// not selected day (but not disabled)
   notSelected
 }

--- a/lib/src/event_decoration.dart
+++ b/lib/src/event_decoration.dart
@@ -1,12 +1,35 @@
 import 'package:flutter/widgets.dart';
 
-typedef EventDecoration EventDecorationBuilder(DateTime date);
+import 'day_picker.dart';
+import 'range_picker.dart';
+import 'week_picker.dart';
 
-/// Class to store styles for event.
+
+/// Signature for function which is used to set set specific decoration for
+/// some days in [DayPicker], [WeekPicker] and [RangePicker].
+///
+/// See also:
+/// * [DayPicker.eventDecorationBuilder]
+/// * [WeekPicker.eventDecorationBuilder]
+/// * [RangePicker.eventDecorationBuilder]
+typedef EventDecorationBuilder = EventDecoration Function(DateTime date);
+
+
+/// Class to store styles for event (specific day in the date picker).
 @immutable
 class EventDecoration {
+
+  /// Cell decoration for the specific day in the date picker (event).
   final BoxDecoration boxDecoration;
+
+  /// Style for number of the specific day in the date picker (event).
   final TextStyle textStyle;
 
+  /// Creates decoration for special day.
+  ///
+  /// Used for [EventDecorationBuilder] function which is usually passed to
+  /// [DayPicker.eventDecorationBuilder], [WeekPicker.eventDecorationBuilder]
+  /// and [RangePicker.eventDecorationBuilder] to set specific decoration for
+  /// some days.
   const EventDecoration({this.boxDecoration, this.textStyle});
 }

--- a/lib/src/icon_btn.dart
+++ b/lib/src/icon_btn.dart
@@ -1,13 +1,33 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-/// Icon button widget built defferent depends on MaterialApp or CupertinoApp ancestor.
+/// Icon button widget built different
+/// depends on [MaterialApp] or [CupertinoApp] ancestor.
 class IconBtn extends StatelessWidget {
+  /// Widget to use inside button.
+  ///
+  /// Typically [Icon] widget.
   final Widget icon;
+
+  /// Function called when user tap on the button.
+  ///
+  /// Can be null. In this case button will be disabled.
   final VoidCallback onTap;
+
+  /// Tooltip for button.
+  ///
+  /// Applied only for material style buttons.
+  /// It means only if widget has [MaterialApp] ancestor.
   final String tooltip;
 
-  const IconBtn({Key key, this.icon, this.onTap, this.tooltip}) : super(key: key);
+  /// Creates button with [icon] different
+  /// depends on [MaterialApp] or [CupertinoApp] ancestor.
+  const IconBtn({
+    Key key,
+    @required this.icon,
+    this.onTap,
+    this.tooltip
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -18,19 +38,17 @@ class IconBtn extends StatelessWidget {
       : _cupertinoBtn();
   }
 
-  Widget _cupertinoBtn() {
-    return CupertinoButton(
-      padding: const EdgeInsets.all(0.0),
-      child: icon,
-      onPressed: onTap,
-    );
-  }
+  Widget _cupertinoBtn() =>
+      CupertinoButton(
+        padding: const EdgeInsets.all(0.0),
+        child: icon,
+        onPressed: onTap,
+      );
 
-  Widget _materialBtn() {
-    return IconButton(
+  Widget _materialBtn() =>
+     IconButton(
        icon: icon,
        tooltip: tooltip ?? "",
        onPressed: onTap,
     );
-  }
 }

--- a/lib/src/layout_settings.dart
+++ b/lib/src/layout_settings.dart
@@ -2,17 +2,23 @@ import 'dart:math' as math;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+import 'day_picker.dart';
+import 'month_picker.dart';
+import 'range_picker.dart';
+import 'week_picker.dart';
 
 // layout defaults
-const Duration _kPageScrollDuration = const Duration(milliseconds: 200);
+const Duration _kPageScrollDuration = Duration(milliseconds: 200);
 const double _kDayPickerRowHeight = 42.0;
 const int _kMaxDayPickerRowCount = 6; // A 31 day month that starts on Saturday.
 const double _kMonthPickerPortraitWidth = 330.0;
 const EdgeInsetsGeometry _kContentPadding =
-    const EdgeInsets.symmetric(horizontal: 8.0);
+    EdgeInsets.symmetric(horizontal: 8.0);
 
+/// Settings for the layout of the [DayPicker], [WeekPicker], [RangePicker]
+/// and [MonthPicker].
 class DatePickerLayoutSettings {
-  /// Duration for scroll to previous or next page
+  /// Duration for scroll to previous or next page.
   final Duration pagesScrollDuration;
 
   /// Determines the scroll physics of a date picker widget.
@@ -20,9 +26,18 @@ class DatePickerLayoutSettings {
   /// Can be null. In this case default physics for [ScrollView] will be used.
   final ScrollPhysics scrollPhysics;
 
+  /// Height of the one row in picker including headers.
+  ///
+  /// Default is [_kDayPickerRowHeight].
   final double dayPickerRowHeight;
+
+  /// Width of the day based pickers.
   final double monthPickerPortraitWidth;
+
+  ///
   final int maxDayPickerRowCount;
+
+  /// Padding for the entire picker.
   final EdgeInsetsGeometry contentPadding;
 
   /// If the first dates from the next month should be shown
@@ -37,13 +52,23 @@ class DatePickerLayoutSettings {
   /// false by default.
   final bool showPrevMonthEnd;
 
+  /// Grid delegate for the picker according to [dayPickerRowHeight] and
+  /// [maxDayPickerRowCount].
   SliverGridDelegate get dayPickerGridDelegate =>
       _DayPickerGridDelegate(dayPickerRowHeight, maxDayPickerRowCount);
 
-  // Two extra rows: one for the day-of-week header and one for the month header.
+  /// Maximum height of the day based picker according to [dayPickerRowHeight]
+  /// and [maxDayPickerRowCount].
+  ///
+  /// Two extra rows:
+  /// one for the day-of-week header and one for the month header.
   double get maxDayPickerHeight =>
       dayPickerRowHeight * (maxDayPickerRowCount + 2);
 
+  /// Creates layout settings for the date picker.
+  ///
+  /// Usually used in [DayPicker], [WeekPicker], [RangePicker]
+  /// and [MonthPicker].
   const DatePickerLayoutSettings({
     this.pagesScrollDuration = _kPageScrollDuration,
     this.dayPickerRowHeight = _kDayPickerRowHeight,
@@ -61,6 +86,7 @@ class DatePickerLayoutSettings {
         assert(showNextMonthStart != null),
         assert(showPrevMonthEnd != null);
 }
+
 
 class _DayPickerGridDelegate extends SliverGridDelegate {
   final double _dayPickerRowHeight;

--- a/lib/src/month_navigation_row.dart
+++ b/lib/src/month_navigation_row.dart
@@ -1,20 +1,50 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_date_pickers/src/icon_btn.dart';
-import 'package:flutter_date_pickers/src/semantic_sorting.dart';
+import 'day_picker.dart' as day_picker;
+import 'icon_btn.dart';
+import 'range_picker.dart';
+import 'semantic_sorting.dart';
+import 'week_picker.dart';
 
+/// Month navigation widget for day based date pickers like
+/// [day_picker.DayPicker],
+/// [WeekPicker],
+/// [RangePicker].
+///
+/// It is row with [title] of showing month in the center and icons to selects
+/// previous and next month around it.
 class MonthNavigationRow extends StatelessWidget {
+  /// Key for previous page icon.
+  ///
+  /// Can be useful in integration tests to find icon.
   final Key previousPageIconKey;
+
+  /// Key for next page icon.
+  ///
+  /// Can be useful in integration tests to find icon.
   final Key nextPageIconKey;
+
+  /// Function called when [nextIcon] is tapped.
   final VoidCallback onNextMonthTapped;
+
+  /// Function called when [prevIcon] is tapped.
   final VoidCallback onPreviousMonthTapped;
+
+  /// Tooltip for the [nextIcon].
   final String nextMonthTooltip;
+
+  /// Tooltip for the [prevIcon].
   final String previousMonthTooltip;
+
+  /// Widget to use at the end of this row (after title).
   final Widget nextIcon;
+
+  /// Widget to use at the beginning of this row (before title).
   final Widget prevIcon;
 
   /// Usually [Text] widget.
   final Widget title;
 
+  /// Creates month navigation row.
   const MonthNavigationRow({
     Key key,
     this.previousPageIconKey,
@@ -31,6 +61,7 @@ class MonthNavigationRow extends StatelessWidget {
         super(key: key);
 
   @override
+  // ignore: prefer_expression_function_bodies
   Widget build(BuildContext context) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/src/range_picker.dart
+++ b/lib/src/range_picker.dart
@@ -1,23 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter_date_pickers/flutter_date_pickers.dart';
-import 'package:flutter_date_pickers/src/date_period.dart';
-import 'package:flutter_date_pickers/src/i_selectable_picker.dart';
-import 'package:flutter_date_pickers/src/layout_settings.dart';
-import 'package:flutter_date_pickers/src/date_picker_keys.dart';
-import 'package:flutter_date_pickers/src/day_based_changable_picker.dart';
-import 'package:flutter_date_pickers/src/typedefs.dart';
 
-// Styles for current displayed period: Theme.of(context).textTheme.subhead
-//
-// Styles for date picker cell:
-// current date: Theme.of(context).textTheme.body2.copyWith(color: themeData.accentColor)
-// if date disabled: Theme.of(context).textTheme.body1.copyWith(color: themeData.disabledColor)
-// if date selected:
-//  text - Theme.of(context).accentTextTheme.body2
-//  for box decoration - color is Theme.of(context).accentColor and box shape is circle
-
-// selectedPeriod must be between firstDate and lastDate
+import 'date_period.dart';
+import 'date_picker_keys.dart';
+import 'date_picker_styles.dart';
+import 'day_based_changable_picker.dart';
+import 'day_type.dart';
+import 'event_decoration.dart';
+import 'i_selectable_picker.dart';
+import 'layout_settings.dart';
+import 'typedefs.dart';
 
 /// Date picker for range selection.
 class RangePicker extends StatelessWidget {
@@ -52,7 +44,8 @@ class RangePicker extends StatelessWidget {
   final ValueChanged<DatePeriod> onChanged;
 
   /// Called when the error was thrown after user selection.
-  /// (e.g. when user selected a range with one or more days what can't be selected)
+  /// (e.g. when user selected a range with one or more days
+  /// that can't be selected)
   final OnSelectionError onSelectionError;
 
   /// The earliest date the user is permitted to pick.
@@ -75,7 +68,7 @@ class RangePicker extends StatelessWidget {
 
   /// Builder to get event decoration for each date.
   ///
-  /// All event styles are overriden by selected styles
+  /// All event styles are overridden by selected styles
   /// except days with dayType is [DayType.notSelected].
   final EventDecorationBuilder eventDecorationBuilder;
 

--- a/lib/src/semantic_sorting.dart
+++ b/lib/src/semantic_sorting.dart
@@ -1,21 +1,33 @@
 import 'package:flutter/semantics.dart';
 
-// Defines semantic traversal order of the top-level widgets inside the day or week
-// picker.
+/// Defines semantic traversal order of the top-level widgets
+/// inside the day or week picker.
 class MonthPickerSortKey extends OrdinalSortKey {
-  static const MonthPickerSortKey previousMonth = const MonthPickerSortKey(1.0);
-  static const MonthPickerSortKey nextMonth = const MonthPickerSortKey(2.0);
-  static const MonthPickerSortKey calendar = const MonthPickerSortKey(3.0);
+  /// Previous month key.
+  static const MonthPickerSortKey previousMonth = MonthPickerSortKey(1.0);
 
+  /// Next month key.
+  static const MonthPickerSortKey nextMonth = MonthPickerSortKey(2.0);
+
+  /// Calendar key.
+  static const MonthPickerSortKey calendar = MonthPickerSortKey(3.0);
+
+  ///
   const MonthPickerSortKey(double order) : super(order);
 }
 
-// Defines semantic traversal order of the top-level widgets inside the month
-// picker.
+/// Defines semantic traversal order of the top-level widgets
+/// inside the month picker.
 class YearPickerSortKey extends OrdinalSortKey {
-  static const YearPickerSortKey previousYear = const YearPickerSortKey(1.0);
-  static const YearPickerSortKey nextYear = const YearPickerSortKey(2.0);
-  static const YearPickerSortKey calendar = const YearPickerSortKey(3.0);
+  /// Previous year key.
+  static const YearPickerSortKey previousYear = YearPickerSortKey(1.0);
 
+  /// Next year key.
+  static const YearPickerSortKey nextYear = YearPickerSortKey(2.0);
+
+  /// Calendar key.
+  static const YearPickerSortKey calendar = YearPickerSortKey(3.0);
+
+  ///
   const YearPickerSortKey(double order) : super(order);
 }

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -1,3 +1,11 @@
-import 'package:flutter_date_pickers/src/unselectable_period_error.dart';
+import 'range_picker.dart';
+import 'unselectable_period_error.dart';
+import 'week_picker.dart';
 
-typedef void OnSelectionError(UnselectablePeriodException e);
+
+/// Signature for function that can be used to handle incorrect selections.
+///
+/// See also:
+/// * [WeekPicker.onSelectionError]
+/// * [RangePicker.onSelectionError]
+typedef OnSelectionError = void Function(UnselectablePeriodException e);

--- a/lib/src/unselectable_period_error.dart
+++ b/lib/src/unselectable_period_error.dart
@@ -1,19 +1,29 @@
 import 'date_period.dart';
+import 'range_picker.dart';
+import 'week_picker.dart';
+
 
 /// Exception thrown when selected period contains custom disabled days.
-
 class UnselectablePeriodException implements Exception {
-  // Dates inside selected period what can't be selected according custom rules.
+  /// Dates inside selected period what can't be selected
+  /// according custom rules.
   final List<DateTime> customDisabledDates;
-  // Selected period wanted by the user
+
+  /// Selected period wanted by the user.
   final DatePeriod period;
 
+  /// Creates exception that stores dates that can not be selected.
+  ///
+  /// See also:
+  /// *[WeekPicker.onSelectionError]
+  /// *[RangePicker.onSelectionError]
   UnselectablePeriodException(this.customDisabledDates, this.period);
 
-  String toString() {
-    return "UnselectablePeriodException: ${customDisabledDates.length} dates inside selected period "
+  String toString() =>
+        "UnselectablePeriodException:"
+        " ${customDisabledDates.length} dates inside selected period "
         "(${period.start} - ${period.end}) "
         "can't be selected according custom rules (selectable pridicate). "
-        "Check 'customDisabledDates' property to get entire list of such dates.";
-  }
+        "Check 'customDisabledDates' property "
+        "to get entire list of such dates.";
 }

--- a/lib/src/unselectable_period_error.dart
+++ b/lib/src/unselectable_period_error.dart
@@ -19,6 +19,7 @@ class UnselectablePeriodException implements Exception {
   /// *[RangePicker.onSelectionError]
   UnselectablePeriodException(this.customDisabledDates, this.period);
 
+  @override
   String toString() =>
         "UnselectablePeriodException:"
         " ${customDisabledDates.length} dates inside selected period "

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,22 +1,21 @@
+/// Bunch of useful functions for date pickers.
 class DatePickerUtils {
-// returns if two objects have same year, month and day
-// time doesn't matter
-  static bool sameDate(DateTime dateTimeOne, DateTime dateTimeTwo) {
-    return dateTimeOne.year == dateTimeTwo.year &&
-        dateTimeOne.month == dateTimeTwo.month &&
-        dateTimeOne.day == dateTimeTwo.day;
-  }
+  /// Returns if two objects have same year, month and day.
+  /// Time doesn't matter.
+  static bool sameDate(DateTime dateTimeOne, DateTime dateTimeTwo) =>
+     dateTimeOne.year == dateTimeTwo.year &&
+     dateTimeOne.month == dateTimeTwo.month &&
+     dateTimeOne.day == dateTimeTwo.day;
 
-// returns if two objects have same year and month
-// day and time don't matter
-  static bool sameMonth(DateTime dateTimeOne, DateTime dateTimeTwo) {
-    return dateTimeOne.year == dateTimeTwo.year &&
-        dateTimeOne.month == dateTimeTwo.month;
-  }
+  /// Returns if two objects have same year and month.
+  /// Day and time don't matter/
+  static bool sameMonth(DateTime dateTimeOne, DateTime dateTimeTwo) =>
+      dateTimeOne.year == dateTimeTwo.year
+      && dateTimeOne.month == dateTimeTwo.month;
 
 
   // Do not use this directly - call getDaysInMonth instead.
-  static const List<int> _daysInMonth = const <int>[
+  static const List<int> _daysInMonth = <int>[
     31,
     -1,
     31,
@@ -48,29 +47,27 @@ class DatePickerUtils {
 
 
   /// Returns number of months between [startDate] and [endDate]
-  static int monthDelta(DateTime startDate, DateTime endDate) {
-    return (endDate.year - startDate.year) * 12 +
+  static int monthDelta(DateTime startDate, DateTime endDate) =>
+     (endDate.year - startDate.year) * 12 +
         endDate.month -
         startDate.month;
-  }
 
 
   /// Add months to a month truncated date.
-  static DateTime addMonthsToMonthDate(DateTime monthDate, int monthsToAdd) {
+  static DateTime addMonthsToMonthDate(DateTime monthDate, int monthsToAdd) =>
     // year is switched automatically if new month > 12
-    return DateTime(monthDate.year, monthDate.month + monthsToAdd);
-  }
+    DateTime(monthDate.year, monthDate.month + monthsToAdd);
 
 
   /// Returns number of years between [startDate] and [endDate]
-  static int yearDelta(DateTime startDate, DateTime endDate) {
-    return (endDate.year - startDate.year);
-  }
+  static int yearDelta(DateTime startDate, DateTime endDate) =>
+     endDate.year - startDate.year;
 
 
   /// Returns start of the first day of the week with given day.
   ///
-  /// Start of the week calculated using firstDayIndex which is int from 0 to 6 where 0 points to Sunday and 6 points to Saturday.
+  /// Start of the week calculated using firstDayIndex which is int from 0 to 6
+  /// where 0 points to Sunday and 6 points to Saturday.
   /// (according to MaterialLocalization.firstDayIfWeekIndex)
   static DateTime getFirstDayOfWeek(DateTime day, int firstDayIndex) {
     // from 1 to 7 where 1 points to Monday and 7 points to Sunday
@@ -89,7 +86,8 @@ class DatePickerUtils {
 
   /// Returns end of the last day of the week with given day.
   ///
-  /// Start of the week calculated using firstDayIndex which is int from 0 to 6 where 0 points to Sunday and 6 points to Saturday.
+  /// Start of the week calculated using firstDayIndex which is int from 0 to 6
+  /// where 0 points to Sunday and 6 points to Saturday.
   /// (according to MaterialLocalization.firstDayIfWeekIndex)
   static DateTime getLastDayOfWeek(DateTime day, int firstDayIndex) {
     // from 1 to 7 where 1 points to Monday and 7 points to Sunday
@@ -112,23 +110,35 @@ class DatePickerUtils {
   /// Returns end of the given day.
   ///
   /// End time is 1 millisecond before start of the next day.
-  static DateTime endOfTheDay(DateTime date) {
-    return DateTime(date.year, date.month, date.day).add(Duration(days: 1)).subtract(Duration(milliseconds: 1));
-  }
+  static DateTime endOfTheDay(DateTime date) =>
+     DateTime(date.year, date.month, date.day)
+        .add(const Duration(days: 1))
+        .subtract(const Duration(milliseconds: 1));
 
   /// Returns start of the given day.
   ///
   /// Start time is 00:00:00.
-  static DateTime startOfTheDay(DateTime date) {
-    return DateTime(date.year, date.month, date.day);
-  }
+  static DateTime startOfTheDay(DateTime date) =>
+     DateTime(date.year, date.month, date.day);
 
-  static DateTime firstShownDate(DateTime curMonth, bool showEndOfPrevMonth, int firstDayOfWeekFromSunday) {
+  /// Returns first shown date for the [curMonth].
+  ///
+  /// First shown date is not always 1st day of the [curMonth].
+  /// It can be day from previous month if [showEndOfPrevMonth] is true.
+  ///
+  /// If [showEndOfPrevMonth] empty day cells before 1st [curMonth]
+  /// are filled with days from the previous month.
+  static DateTime firstShownDate({
+      DateTime curMonth,
+      bool showEndOfPrevMonth,
+      int firstDayOfWeekFromSunday}) {
+
     DateTime result = DateTime(curMonth.year, curMonth.month, 1);
 
     if (showEndOfPrevMonth) {
       assert(firstDayOfWeekFromSunday != null);
-      int firstDayOffset = computeFirstDayOffset(curMonth.year, curMonth.month, firstDayOfWeekFromSunday);
+      int firstDayOffset = computeFirstDayOffset(curMonth.year, curMonth.month,
+          firstDayOfWeekFromSunday);
       if (firstDayOffset == 0) return null;
 
 
@@ -147,13 +157,26 @@ class DatePickerUtils {
     return result;
   }
 
-  static DateTime lastShownDate(DateTime curMonth, bool showStartNextMonth, int firstDayOfWeekFromSunday) {
+
+  /// Returns last shown date for the [curMonth].
+  ///
+  /// Last shown date is not always last day of the [curMonth].
+  /// It can be day from next month if [showStartNextMonth] is true.
+  ///
+  /// If [showStartNextMonth] empty day cells after last day of [curMonth]
+  /// are filled with days from the next month.
+  static DateTime lastShownDate({
+      DateTime curMonth,
+      bool showStartNextMonth,
+      int firstDayOfWeekFromSunday}) {
+
     int daysInCurMonth = getDaysInMonth(curMonth.year, curMonth.month);
     DateTime result = DateTime(curMonth.year, curMonth.month, daysInCurMonth);
 
     if (showStartNextMonth) {
       assert(firstDayOfWeekFromSunday != null);
-      int firstDayOffset = computeFirstDayOffset(curMonth.year, curMonth.month, firstDayOfWeekFromSunday);
+      int firstDayOffset = computeFirstDayOffset(curMonth.year, curMonth.month,
+          firstDayOfWeekFromSunday);
 
       int totalDays = firstDayOffset + daysInCurMonth;
       int trailingDaysCount = 7 - totalDays % 7;
@@ -194,9 +217,9 @@ class DatePickerUtils {
   ///
   /// - [DateTime.weekday] provides a 1-based index into days of week, with 1
   ///   falling on Monday.
-  /// - [MaterialLocalizations.firstDayOfWeekIndex] provides a 0-based index
-  ///   into the [MaterialLocalizations.narrowWeekdays] list.
-  /// - [MaterialLocalizations.narrowWeekdays] list provides localized names of
+  /// - MaterialLocalizations.firstDayOfWeekIndex provides a 0-based index
+  ///   into the MaterialLocalizations.narrowWeekdays list.
+  /// - MaterialLocalizations.narrowWeekdays list provides localized names of
   ///   days of week, always starting with Sunday and ending with Saturday.
   static int computeFirstDayOffset(
       int year, int month, int firstDayOfWeekFromSunday) {

--- a/lib/src/week_picker.dart
+++ b/lib/src/week_picker.dart
@@ -1,24 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter_date_pickers/src/date_picker_styles.dart';
-import 'package:flutter_date_pickers/src/event_decoration.dart';
-import 'package:flutter_date_pickers/src/i_selectable_picker.dart';
-import 'package:flutter_date_pickers/src/layout_settings.dart';
-import 'package:flutter_date_pickers/src/date_period.dart';
-import 'package:flutter_date_pickers/src/date_picker_keys.dart';
-import 'package:flutter_date_pickers/src/day_based_changable_picker.dart';
-import 'package:flutter_date_pickers/src/typedefs.dart';
 
-// Styles for current displayed period (month): Theme.of(context).textTheme.subhead
-//
-// Styles for date picker cell:
-// current date: Theme.of(context).textTheme.body2.copyWith(color: themeData.accentColor)
-// if date disabled: Theme.of(context).textTheme.body1.copyWith(color: themeData.disabledColor)
-// if date selected:
-//  text - Theme.of(context).accentTextTheme.body2
-//  for box decoration - color is Theme.of(context).accentColor and box shape is circle
-
-// selectedDate must be between firstDate and lastDate
+import 'date_period.dart';
+import 'date_picker_keys.dart';
+import 'date_picker_styles.dart';
+import 'day_based_changable_picker.dart';
+import 'day_type.dart';
+import 'event_decoration.dart';
+import 'i_selectable_picker.dart';
+import 'layout_settings.dart';
+import 'typedefs.dart';
 
 /// Date picker for selection a week.
 class WeekPicker extends StatelessWidget {
@@ -53,7 +44,8 @@ class WeekPicker extends StatelessWidget {
   final ValueChanged<DatePeriod> onChanged;
 
   /// Called when the error was thrown after user selection.
-  /// (e.g. when user selected a week with one or more days what can't be selected)
+  /// (e.g. when user selected a week with one or more days
+  /// what can't be selected)
   final OnSelectionError onSelectionError;
 
   /// The earliest date the user is permitted to pick.
@@ -80,6 +72,7 @@ class WeekPicker extends StatelessWidget {
   /// except days with dayType is [DayType.notSelected].
   final EventDecorationBuilder eventDecorationBuilder;
 
+
   /// Called when the user changes the month.
   /// New DateTime object represents first day of new month and 00:00 time.
   final ValueChanged<DateTime> onMonthChanged;
@@ -88,8 +81,11 @@ class WeekPicker extends StatelessWidget {
   Widget build(BuildContext context) {
     MaterialLocalizations localizations = MaterialLocalizations.of(context);
 
+    int firstDayOfWeekIndex = datePickerStyles.firstDayOfeWeekIndex
+        ?? localizations.firstDayOfWeekIndex;
+
     ISelectablePicker<DatePeriod> weekSelectablePicker = WeekSelectable(
-        selectedDate, datePickerStyles.firstDayOfeWeekIndex ?? localizations.firstDayOfWeekIndex, firstDate, lastDate,
+        selectedDate, firstDayOfWeekIndex, firstDate, lastDate,
         selectableDayPredicate: selectableDayPredicate);
 
     return DayBasedChangeablePicker<DatePeriod>(


### PR DESCRIPTION
Added effective dart linter rules and pedantic(1.9.2) linter rules.
Duplicated are removed.

Two rules are disabled:
- **omit_local_variable_types**. I prefer add types even for local variable because with it I can quickly open type declaration with IDE hot keys. Also I find it useful to quickly understand what is happening.

- **prefer_single_quotes**. I can't find reasonable explanation why strings should be single quoted. With string interpolation it can be dangerous if some injected string contains apostrophe.