### PR TITLE
Day multi selection

### DIFF
--- a/example/lib/date_pickers_widgets/days_picker_page.dart
+++ b/example/lib/date_pickers_widgets/days_picker_page.dart
@@ -5,20 +5,20 @@ import '../color_picker_dialog.dart';
 import '../color_selector_btn.dart';
 import '../event.dart';
 
-/// Page with [dp.DayPicker].
-class DayPickerPage extends StatefulWidget {
+/// Page with [dp.DayPicker] where many single days can be selected.
+class DaysPickerPage extends StatefulWidget {
   /// Custom events.
   final List<Event> events;
 
-  ///
-  const DayPickerPage({Key key, this.events}) : super(key: key);
+  /// 
+  const DaysPickerPage({Key key, this.events}) : super(key: key);
 
   @override
-  State<StatefulWidget> createState() => _DayPickerPageState();
+  State<StatefulWidget> createState() => _DaysPickerPageState();
 }
 
-class _DayPickerPageState extends State<DayPickerPage> {
-  DateTime _selectedDate;
+class _DaysPickerPageState extends State<DaysPickerPage> {
+  List<DateTime> _selectedDates;
   DateTime _firstDate;
   DateTime _lastDate;
   Color selectedDateStyleColor;
@@ -28,7 +28,14 @@ class _DayPickerPageState extends State<DayPickerPage> {
   void initState() {
     super.initState();
 
-    _selectedDate = DateTime.now();
+    final now = DateTime.now();
+
+    _selectedDates = [
+      now,
+      now.subtract(Duration(days: 10)),
+      now.add(Duration(days: 7))
+    ];
+
     _firstDate = DateTime.now().subtract(Duration(days: 45));
     _lastDate = DateTime.now().add(Duration(days: 45));
   }
@@ -59,8 +66,8 @@ class _DayPickerPageState extends State<DayPickerPage> {
           : Axis.horizontal,
       children: <Widget>[
         Expanded(
-          child: dp.DayPicker.single(
-            selectedDate: _selectedDate,
+          child: dp.DayPicker.multi(
+            selectedDates: _selectedDates,
             onChanged: _onSelectedDateChanged,
             firstDate: _firstDate,
             lastDate: _lastDate,
@@ -108,7 +115,7 @@ class _DayPickerPageState extends State<DayPickerPage> {
                     ],
                   ),
                 ),
-                Text("Selected: $_selectedDate")
+                Text("Selected: $_selectedDates")
               ],
             ),
           ),
@@ -147,9 +154,9 @@ class _DayPickerPageState extends State<DayPickerPage> {
     }
   }
 
-  void _onSelectedDateChanged(DateTime newDate) {
+  void _onSelectedDateChanged(List<DateTime> newDates) {
     setState(() {
-      _selectedDate = newDate;
+      _selectedDates = newDates;
     });
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_date_picker/date_pickers_widgets/days_picker_page.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'date_pickers_widgets/day_picker_page.dart';
+import 'date_pickers_widgets/days_picker_page.dart';
 import 'date_pickers_widgets/month_picker_page.dart';
 import 'date_pickers_widgets/range_picker_page.dart';
 import 'date_pickers_widgets/week_picker_page.dart';

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_date_picker/date_pickers_widgets/days_picker_page.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'date_pickers_widgets/day_picker_page.dart';
@@ -60,6 +61,7 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
 
   final List<Widget> datePickers = <Widget>[
     DayPickerPage(events: events,),
+    DaysPickerPage(),
     WeekPickerPage(events: events,),
     RangePickerPage(events: events,),
     MonthPickerPage()
@@ -101,6 +103,8 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
           items: [
             BottomNavigationBarItem(
                 icon: Icon(Icons.date_range), title: Text("Day")),
+            BottomNavigationBarItem(
+                icon: Icon(Icons.date_range), title: Text("Days")),
             BottomNavigationBarItem(
                 icon: Icon(Icons.date_range), title: Text("Week")),
             BottomNavigationBarItem(

--- a/lib/src/basic_day_based_widget.dart
+++ b/lib/src/basic_day_based_widget.dart
@@ -100,8 +100,6 @@ class DayBasedPicker<T> extends StatelessWidget with CommonDatePickerFunctions {
   }
 
   List<Widget> _buildHeaders(MaterialLocalizations localizations) {
-    Map m;
-    m[1] = 2;
     final int firstDayOfWeekIndex = datePickerStyles.firstDayOfeWeekIndex ??
         localizations.firstDayOfWeekIndex;
 

--- a/lib/src/day_based_changable_picker.dart
+++ b/lib/src/day_based_changable_picker.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_date_pickers/src/day_picker_selection.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'basic_day_based_widget.dart';
 import 'date_picker_keys.dart';
 import 'date_picker_styles.dart';
 import 'day_based_changeable_picker_presenter.dart';
+import 'day_picker_selection.dart';
 import 'day_type.dart';
 import 'event_decoration.dart';
 import 'i_selectable_picker.dart';

--- a/lib/src/day_based_changable_picker.dart
+++ b/lib/src/day_based_changable_picker.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_date_pickers/src/day_picker_selection.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 import 'basic_day_based_widget.dart';
@@ -22,7 +23,7 @@ class DayBasedChangeablePicker<T> extends StatefulWidget {
   /// The currently selected date.
   ///
   /// This date is highlighted in the picker.
-  final DateTime selectedDate;
+  final DayPickerSelection selection;
 
   /// Called when the user picks a new T.
   final ValueChanged<T> onChanged;
@@ -58,9 +59,9 @@ class DayBasedChangeablePicker<T> extends StatefulWidget {
   final ValueChanged<DateTime> onMonthChanged;
 
   /// Create picker with option to change month.
-  const DayBasedChangeablePicker(
+  DayBasedChangeablePicker(
       {Key key,
-      this.selectedDate,
+      @required this.selection,
       this.onChanged,
       @required this.firstDate,
       @required this.lastDate,
@@ -73,6 +74,7 @@ class DayBasedChangeablePicker<T> extends StatefulWidget {
       this.onMonthChanged})
       : assert(datePickerLayoutSettings != null),
         assert(datePickerStyles != null),
+        assert(selection != null && selection.isNotEmpty),
         super(key: key);
 
   @override
@@ -103,7 +105,7 @@ class _DayBasedChangeablePickerState<T>
 
     // Initially display the pre-selected date.
     final int monthPage =
-        DatePickerUtils.monthDelta(widget.firstDate, widget.selectedDate);
+        DatePickerUtils.monthDelta(widget.firstDate, widget.selection.earliest);
     _dayPickerController = PageController(initialPage: monthPage);
 
     _changesSubscription = widget.selectablePicker.onUpdate
@@ -112,11 +114,13 @@ class _DayBasedChangeablePickerState<T>
               ? widget.onSelectionError(e)
               : print(e.toString()));
 
+    // todo: do we really need to do it. Above we have calculation month page
+    // todo: for the PageController.
     // Give information about initial selection to presenter.
     // It should be done after first frame when PageView is already created.
     // Otherwise event from presenter will cause a error.
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      _presenter.setSelectedDate(widget.selectedDate);
+      _presenter.setSelectedDate(widget.selection.earliest);
     });
 
     _updateCurrentDate();
@@ -126,8 +130,8 @@ class _DayBasedChangeablePickerState<T>
   void didUpdateWidget(DayBasedChangeablePicker oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (widget.selectedDate != oldWidget.selectedDate) {
-      _presenter.setSelectedDate(widget.selectedDate);
+    if (widget.selection.earliest != oldWidget.selection.earliest) {
+      _presenter.setSelectedDate(widget.selection.earliest);
     }
 
     if (widget.datePickerStyles != oldWidget.datePickerStyles) {

--- a/lib/src/day_picker.dart
+++ b/lib/src/day_picker.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_date_pickers/src/day_picker_selection.dart';
 
 import 'date_picker_keys.dart';
 import 'date_picker_styles.dart';
@@ -9,21 +10,25 @@ import 'i_selectable_picker.dart';
 import 'layout_settings.dart';
 
 /// Date picker for selection one day.
-class DayPicker extends StatelessWidget {
+class DayPicker<T> extends StatelessWidget {
+
   /// Creates a day picker.
-  DayPicker(
-      {Key key,
-      @required this.selectedDate,
-      @required this.onChanged,
-      @required this.firstDate,
-      @required this.lastDate,
-      this.datePickerLayoutSettings = const DatePickerLayoutSettings(),
-      this.datePickerStyles,
-      this.datePickerKeys,
-      this.selectableDayPredicate,
-      this.eventDecorationBuilder,
-      this.onMonthChanged})
-      : assert(selectedDate != null),
+  DayPicker.single({Key key,
+    @required DateTime selectedDate,
+    @required this.onChanged,
+    @required this.firstDate,
+    @required this.lastDate,
+    this.datePickerLayoutSettings = const DatePickerLayoutSettings(),
+    this.datePickerStyles,
+    this.datePickerKeys,
+    this.selectableDayPredicate,
+    this.eventDecorationBuilder,
+    this.onMonthChanged}) :
+        selection = DayPickerSingleSelection(selectedDate),
+        selectionLogic =  DaySelectable(
+            selectedDate, firstDate, lastDate,
+            selectableDayPredicate: selectableDayPredicate),
+        assert(selectedDate != null),
         assert(onChanged != null),
         assert(!firstDate.isAfter(lastDate)),
         assert(!lastDate.isBefore(firstDate)),
@@ -31,13 +36,38 @@ class DayPicker extends StatelessWidget {
         assert(!selectedDate.isAfter(lastDate)),
         super(key: key);
 
+
+  DayPicker.multi({Key key,
+    @required List<DateTime> selectedDates,
+    @required this.onChanged,
+    @required this.firstDate,
+    @required this.lastDate,
+    this.datePickerLayoutSettings = const DatePickerLayoutSettings(),
+    this.datePickerStyles,
+    this.datePickerKeys,
+    this.selectableDayPredicate,
+    this.eventDecorationBuilder,
+    this.onMonthChanged}) :
+        selection = DayPickerMultiSelection(selectedDates),
+        selectionLogic =  DayMultiSelectable(
+            selectedDates, firstDate, lastDate,
+            selectableDayPredicate: selectableDayPredicate),
+        assert(selectedDates != null),
+        assert(onChanged != null),
+        assert(!firstDate.isAfter(lastDate)),
+        assert(!lastDate.isBefore(firstDate)),
+        // assert(!selection.isBefore(firstDate)),
+        // assert(!selection.isAfter(lastDate)),
+        super(key: key);
+
+
   /// The currently selected date.
   ///
   /// This date is highlighted in the picker.
-  final DateTime selectedDate;
+  final DayPickerSelection selection;
 
   /// Called when the user picks a day.
-  final ValueChanged<DateTime> onChanged;
+  final ValueChanged<T> onChanged;
 
   /// The earliest date the user is permitted to pick.
   final DateTime firstDate;
@@ -66,16 +96,14 @@ class DayPicker extends StatelessWidget {
   // Called when the user changes the month.
   /// New DateTime object represents first day of new month and 00:00 time.
   final ValueChanged<DateTime> onMonthChanged;
-
+  
+  final ISelectablePicker selectionLogic;
+  
   @override
   Widget build(BuildContext context) {
-    ISelectablePicker<DateTime> daySelectablePicker = DaySelectable(
-        selectedDate, firstDate, lastDate,
-        selectableDayPredicate: selectableDayPredicate);
-
-    return DayBasedChangeablePicker<DateTime>(
-      selectablePicker: daySelectablePicker,
-      selectedDate: selectedDate,
+    return DayBasedChangeablePicker<T>(
+      selectablePicker: selectionLogic,
+      selection: selection,
       firstDate: firstDate,
       lastDate: lastDate,
       onChanged: onChanged,

--- a/lib/src/day_picker.dart
+++ b/lib/src/day_picker.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_date_pickers/src/day_picker_selection.dart';
 
 import 'date_picker_keys.dart';
 import 'date_picker_styles.dart';
 import 'day_based_changable_picker.dart';
+import 'day_picker_selection.dart';
 import 'day_type.dart';
 import 'event_decoration.dart';
 import 'i_selectable_picker.dart';
@@ -12,7 +12,10 @@ import 'layout_settings.dart';
 /// Date picker for selection one day.
 class DayPicker<T> extends StatelessWidget {
 
-  /// Creates a day picker.
+  /// Creates a day picker where only one single day can be selected.
+  ///
+  /// See also:
+  /// * [DayPicker.multi] - day picker where many single days can be selected.
   DayPicker.single({Key key,
     @required DateTime selectedDate,
     @required this.onChanged,
@@ -37,6 +40,11 @@ class DayPicker<T> extends StatelessWidget {
         super(key: key);
 
 
+  /// Creates a day picker  where many single days can be selected.
+  ///
+  /// See also:
+  /// * [DayPicker.single] - day picker where only one single day
+  /// can be selected.
   DayPicker.multi({Key key,
     @required List<DateTime> selectedDates,
     @required this.onChanged,
@@ -96,10 +104,12 @@ class DayPicker<T> extends StatelessWidget {
   // Called when the user changes the month.
   /// New DateTime object represents first day of new month and 00:00 time.
   final ValueChanged<DateTime> onMonthChanged;
-  
+
+  /// Logic to handle user's selections.
   final ISelectablePicker selectionLogic;
   
   @override
+  // ignore: prefer_expression_function_bodies
   Widget build(BuildContext context) {
     return DayBasedChangeablePicker<T>(
       selectablePicker: selectionLogic,

--- a/lib/src/day_picker_selection.dart
+++ b/lib/src/day_picker_selection.dart
@@ -1,0 +1,84 @@
+
+import 'package:flutter_date_pickers/flutter_date_pickers.dart';
+import 'package:flutter_date_pickers/src/utils.dart';
+
+abstract class DayPickerSelection {
+  bool isBefore(DateTime dateTime);
+  bool isAfter(DateTime dateTime);
+  DateTime get earliest;
+  bool get isEmpty;
+  bool get isNotEmpty;
+
+  // This constructor allows children to have constant constructor.
+  const DayPickerSelection();
+}
+
+class DayPickerSingleSelection extends DayPickerSelection {
+  final DateTime selectedDate;
+
+  const DayPickerSingleSelection(this.selectedDate)
+      : assert(selectedDate != null);
+
+  @override
+  bool isAfter(DateTime dateTime) => selectedDate.isAfter(dateTime);
+
+  @override
+  bool isBefore(DateTime dateTime) => selectedDate.isAfter(dateTime);
+
+  @override
+  DateTime get earliest => selectedDate;
+
+  @override
+  bool get isEmpty => selectedDate == null;
+
+  @override
+  bool get isNotEmpty => selectedDate != null;
+}
+
+class DayPickerMultiSelection extends DayPickerSelection {
+  final List<DateTime> selectedDates;
+
+  DayPickerMultiSelection(this.selectedDates)
+      : assert(selectedDates != null && selectedDates.isNotEmpty);
+
+
+  @override
+  bool isAfter(DateTime dateTime)
+  => selectedDates.every((d) => d.isAfter(dateTime));
+
+  @override
+  bool isBefore(DateTime dateTime)
+  => selectedDates.every((d) => d.isBefore(dateTime));
+
+  @override
+  DateTime get earliest => DatePickerUtils.getEarliestFromList(selectedDates);
+
+  @override
+  bool get isEmpty => selectedDates.isEmpty;
+
+  @override
+  bool get isNotEmpty => selectedDates.isNotEmpty;
+}
+
+
+class DayPickerRangeSelection extends DayPickerSelection {
+  final DatePeriod selectedRange;
+
+  const DayPickerRangeSelection(this.selectedRange)
+      : assert(selectedRange != null);
+
+  @override
+  DateTime get earliest => selectedRange.start;
+
+  @override
+  bool isAfter(DateTime dateTime) => selectedRange.start.isAfter(dateTime);
+
+  @override
+  bool isBefore(DateTime dateTime) => selectedRange.end.isBefore(dateTime);
+
+  @override
+  bool get isEmpty => selectedRange == null;
+
+  @override
+  bool get isNotEmpty => selectedRange != null;
+}

--- a/lib/src/day_picker_selection.dart
+++ b/lib/src/day_picker_selection.dart
@@ -1,21 +1,39 @@
+import 'date_period.dart';
+import 'utils.dart';
 
-import 'package:flutter_date_pickers/flutter_date_pickers.dart';
-import 'package:flutter_date_pickers/src/utils.dart';
-
+/// Base class for day based pickers selection.
 abstract class DayPickerSelection {
+
+  /// If this is before [dateTime].
   bool isBefore(DateTime dateTime);
+
+  /// If this is after [dateTime].
   bool isAfter(DateTime dateTime);
+
+  /// Returns earliest [DateTime] in this selection.
   DateTime get earliest;
+
+  /// If this selection is empty.
   bool get isEmpty;
+
+  /// If this selection is not empty.
   bool get isNotEmpty;
 
-  // This constructor allows children to have constant constructor.
+  /// Constructor to allow children to have constant constructor.
   const DayPickerSelection();
 }
 
+/// Selection with only one selected date.
+///
+/// See also:
+/// * [DayPickerMultiSelection] - selection with one or many single dates.
+/// * [DayPickerRangeSelection] - date period selection.
 class DayPickerSingleSelection extends DayPickerSelection {
+
+  /// Selected date.
   final DateTime selectedDate;
 
+  /// Creates selection with only one selected date.
   const DayPickerSingleSelection(this.selectedDate)
       : assert(selectedDate != null);
 
@@ -35,9 +53,18 @@ class DayPickerSingleSelection extends DayPickerSelection {
   bool get isNotEmpty => selectedDate != null;
 }
 
+
+/// Selection with one or many single dates.
+///
+/// See also:
+/// * [DayPickerSingleSelection] - selection with only one selected date.
+/// * [DayPickerRangeSelection] - date period selection.
 class DayPickerMultiSelection extends DayPickerSelection {
+
+  /// List of the selected dates.
   final List<DateTime> selectedDates;
 
+  /// Selection with one or many single dates.
   DayPickerMultiSelection(this.selectedDates)
       : assert(selectedDates != null && selectedDates.isNotEmpty);
 
@@ -61,9 +88,18 @@ class DayPickerMultiSelection extends DayPickerSelection {
 }
 
 
+
+/// Date period selection.
+///
+/// See also:
+/// * [DayPickerSingleSelection] - selection with only one selected date.
+/// * [DayPickerMultiSelection] - selection with one or many single dates.
 class DayPickerRangeSelection extends DayPickerSelection {
+
+  /// Selected period.
   final DatePeriod selectedRange;
 
+  /// Date period selection.
   const DayPickerRangeSelection(this.selectedRange)
       : assert(selectedRange != null);
 

--- a/lib/src/range_picker.dart
+++ b/lib/src/range_picker.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_date_pickers/src/day_picker_selection.dart';
 
 import 'date_period.dart';
 import 'date_picker_keys.dart';
@@ -84,7 +85,7 @@ class RangePicker extends StatelessWidget {
 
     return DayBasedChangeablePicker<DatePeriod>(
       selectablePicker: rangeSelectablePicker,
-      selectedDate: selectedPeriod.start,
+      selection: DayPickerRangeSelection(selectedPeriod),
       firstDate: firstDate,
       lastDate: lastDate,
       onChanged: onChanged,

--- a/lib/src/range_picker.dart
+++ b/lib/src/range_picker.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter_date_pickers/src/day_picker_selection.dart';
 
 import 'date_period.dart';
 import 'date_picker_keys.dart';
 import 'date_picker_styles.dart';
 import 'day_based_changable_picker.dart';
+import 'day_picker_selection.dart';
 import 'day_type.dart';
 import 'event_decoration.dart';
 import 'i_selectable_picker.dart';

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -231,4 +231,20 @@ class DatePickerUtils {
     // and the day corresponding to the 1-st of the month.
     return (weekdayFromMonday - firstDayOfWeekFromMonday) % 7;
   }
+
+  /// Returns earliest [DateTime] from the list.
+  ///
+  /// [dates] must not be null.
+  /// In case it is null, [ArgumentError] will be thrown.
+  static DateTime getEarliestFromList(List<DateTime> dates) {
+    ArgumentError.checkNotNull(dates, "dates");
+
+    return dates.fold(dates[0], getEarliest);
+  }
+
+  /// Returns earliest [DateTime] from two.
+  ///
+  /// If two [DateTime]s is the same moment first ([a]) will be return.
+  static DateTime getEarliest(DateTime a, DateTime b)
+    => a.isBefore(b) ? a : b;
 }

--- a/lib/src/week_picker.dart
+++ b/lib/src/week_picker.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_date_pickers/src/day_picker_selection.dart';
 
 import 'date_period.dart';
 import 'date_picker_keys.dart';
@@ -90,7 +91,9 @@ class WeekPicker extends StatelessWidget {
 
     return DayBasedChangeablePicker<DatePeriod>(
       selectablePicker: weekSelectablePicker,
-      selectedDate: selectedDate,
+      // todo: maybe create selection for week
+      // todo: and change logic here to work with it
+      selection: DayPickerSingleSelection(selectedDate),
       firstDate: firstDate,
       lastDate: lastDate,
       onChanged: onChanged,

--- a/lib/src/week_picker.dart
+++ b/lib/src/week_picker.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter_date_pickers/src/day_picker_selection.dart';
 
 import 'date_period.dart';
 import 'date_picker_keys.dart';
 import 'date_picker_styles.dart';
 import 'day_based_changable_picker.dart';
+import 'day_picker_selection.dart';
 import 'day_type.dart';
 import 'event_decoration.dart';
 import 'i_selectable_picker.dart';


### PR DESCRIPTION
This addresses Issue #31 

Added support for DayPicker where many single days can be selected.
Removed default constructor for ```DayPicker``` and added 2 named constructor:

- ```DayPicker.single``` to create DayPicker where only single day can be selected.
- ```DayPicker.multi``` to create DayPicker where many single days can be selected.

Refactored handling selection in all day based date pickers (```DayPicker```, ```WeekPicker```, ```RangePicker```). Added ```DayPickerSelection``` class for it.
