### PR TITLE
fixed timer bug in MonthPicker

### DIFF
--- a/lib/src/month_picker.dart
+++ b/lib/src/month_picker.dart
@@ -267,6 +267,7 @@ class _MonthPickerState<T extends Object> extends State<MonthPicker<T>> {
 
   @override
   void dispose() {
+    _timer?.cancel();
     _changesSubscription?.cancel();
     super.dispose();
   }


### PR DESCRIPTION
added _timer?.cancel() in dispose of `MonthPicker`

closes #70  