### PR TITLE
Remove redundant null check

### DIFF
--- a/lib/src/i_selectable_picker.dart
+++ b/lib/src/i_selectable_picker.dart
@@ -66,7 +66,7 @@ abstract class ISelectablePicker<T> {
   /// If [_selectableDayPredicate] is set checks it as well.
   @protected
   bool isDisabled(DateTime day) {
-    final bool customDisabled = _selectableDayPredicate(day);
+    final bool customDisabled = !_selectableDayPredicate(day);
 
     return day.isAfter(lastDate) || day.isBefore(firstDate) || customDisabled;
   }

--- a/lib/src/i_selectable_picker.dart
+++ b/lib/src/i_selectable_picker.dart
@@ -58,9 +58,9 @@ abstract class ISelectablePicker<T> {
   /// Call when user tap on the day cell.
   void onDayTapped(DateTime selectedDate);
 
-  /// Returns if given day is disabled.
+  /// Returns true if given day is disabled.
   ///
-  /// Returns weather given day before the beginning of the [firstDate]
+  /// Returns whether the given day is before the beginning of the [firstDate]
   /// or after the end of the [lastDate].
   ///
   /// If [_selectableDayPredicate] is set checks it as well.

--- a/lib/src/i_selectable_picker.dart
+++ b/lib/src/i_selectable_picker.dart
@@ -65,11 +65,8 @@ abstract class ISelectablePicker<T> {
   ///
   /// If [_selectableDayPredicate] is set checks it as well.
   @protected
-  bool isDisabled(DateTime day) {
-    final bool customDisabled = !_selectableDayPredicate(day);
-
-    return day.isAfter(lastDate) || day.isBefore(firstDate) || customDisabled;
-  }
+  bool isDisabled(DateTime day) =>
+    day.isAfter(lastDate) || day.isBefore(firstDate) || !_selectableDayPredicate(day);
 
   /// Closes [onUpdateController].
   /// After it [onUpdateController] can't get new events.

--- a/lib/src/i_selectable_picker.dart
+++ b/lib/src/i_selectable_picker.dart
@@ -66,8 +66,7 @@ abstract class ISelectablePicker<T> {
   /// If [_selectableDayPredicate] is set checks it as well.
   @protected
   bool isDisabled(DateTime day) {
-    final bool customDisabled =
-        _selectableDayPredicate != null ? !_selectableDayPredicate(day) : false;
+    final bool customDisabled = _selectableDayPredicate(day);
 
     return day.isAfter(lastDate) || day.isBefore(firstDate) || customDisabled;
   }


### PR DESCRIPTION
The check is redundant according to the static analysis https://pub.dev/packages/flutter_date_pickers/score